### PR TITLE
chore: expose postgres to localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,9 @@ NGINX_HTTP_PORT=80
 NGINX_HTTPS_PORT=443
 DNS_PORT=53
 
+# Port for PostgreSQL (only exposed to localhost)
+POSTGRES_PORT=2345
+
 # Password for redis
 REDIS_PASSWORD=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
   postgres:
     restart: unless-stopped
     image: postgres:14-alpine
+    ports:
+      - 127.0.0.1:${POSTGRES_PORT}:5432
     volumes:
       - pgdata:/var/lib/postgresql/data
     networks:


### PR DESCRIPTION
allows easier use of remote DB management (i.e. datagrip)